### PR TITLE
Adição de lógica para exibir endereço do usuário após a inserção do CEP através de fetch API

### DIFF
--- a/css/form.css
+++ b/css/form.css
@@ -22,6 +22,12 @@
   margin: 20px 0;
 }
 
+.endereco {
+  display: none;
+  margin-bottom: 20px;
+  color: #1f6b62;
+}
+
 /*Estilo para iPad e desktop - tudo o que quero que mude nesses dispositivos coloco aqui*/
 
 @media (min-width: 760px) {

--- a/index.html
+++ b/index.html
@@ -72,7 +72,10 @@
                 </div> 
                 <div class="personalInfo__input">
                   <input id="zipCode" type="number" name="cepUsuario" required placeholder="Digite seu CEP">
-                </div>       
+                </div> 
+                <div id="address" class="endereco">
+
+                </div>      
               </div> 
             </div> 
           </div>  

--- a/js/script.js
+++ b/js/script.js
@@ -1,0 +1,32 @@
+const cepInput = document.querySelector('#zipCode');
+cepInput.addEventListener("keyup", function() {
+
+  const cep = cepInput.value;
+  console.log(cep);
+
+  if(cep.length == 8) {
+    //const URL = 'https://api.postmon.com.br/v1/cep/' + cep;
+    //fetch(URL)
+
+    fetch(`https://api.postmon.com.br/v1/cep/${cep}`)
+      .then(function(response) {
+        if(response.ok) {
+          return response.json();
+        }
+        throw new Error('Network response was not ok.');
+      })
+      .then(function(endereco) { //endereco é a promise (promessa de resposta) response resolvida
+        
+        const enderecoCompleto = document.querySelector('#address');
+
+        enderecoCompleto.style.display = "block";
+
+        enderecoCompleto.innerHTML = "Seu endereço é " + endereco.logradouro + ", " + endereco.bairro + ", " + endereco.cidade + ", " + endereco.estado + "."
+      })
+      .catch(function(error) {
+        console.log('There has been a problem with your fetch operation: ', error.message);
+      });   
+  }
+});
+
+


### PR DESCRIPTION
**Por quê?**

Em continuidade ao projeto Survey Form, do freeCodeCamp, essa história teve como objetivo adicionar lógica para exibir o endereço do usuário após o preenchimento do campo CEP do formulário.

**O que foi feito?**

Utilizamos o método `fetch` do `fetch API` para retornar o endereço do usuário logo que o campo CEP do formulário é preenchido.

**Como ficou?**

MOBILE:

![mobilecep](https://user-images.githubusercontent.com/37075313/50916625-b3d47680-1422-11e9-8108-b61f2d9d3877.gif)

DESKTOP:

![desktopcep](https://user-images.githubusercontent.com/37075313/50916633-bafb8480-1422-11e9-93ac-573d250afa54.gif)

